### PR TITLE
Fix markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Good News
+# Good News
 Good news, everyone!  LinqToStdf is now using Git, and we'll happily take pull requests that line up with the principles of the project.  We owe you guys a list of those things, but we'll happily take a look at requests and let you know until we have them documented. ;)
-#Project Description
+# Project Description
 A library for parsing/processing Standard Test Datalog Format (STDF) files, typically used in semiconductor testing.
-#Features
+# Features
 * Parsing of the general STDF file structure
 * Support for Linq style queries over STDF files
 * Specific support for the STDF V4 spec, including "structured" extensions.  For example, get all the Parametric Test Records for a given Part (from PIR or PRR).
@@ -21,13 +21,13 @@ A library for parsing/processing Standard Test Datalog Format (STDF) files, typi
   * Built-in filters for things like synthesizing summary records and enforcing STDF V4 record ordering.
 * "Pre-compiled" queries, allowing you to leverage the richness of the API and the performance of a single-use parser.
 
-##[We need corrupt STDFs]!
+## [We need corrupt STDFs]!
 
-#General Overview
+# General Overview
 For a general overview, go see the [Basic Idea]
 
-#Motivation
+# Motivation
 Discover the [Motivation] behind the library.
 
-#Example Usage
+# Example Usage
 See [Example Usage]


### PR DESCRIPTION
Added spaces after header markers so the rendered README has headers